### PR TITLE
Conditionally create device client based on mode

### DIFF
--- a/uploadflights.py
+++ b/uploadflights.py
@@ -297,7 +297,8 @@ def main():
     if (len(sys.argv) > 1):
         config_file = sys.argv[1]
         get_configuration(config_file)
-        device_client = IoTHubDeviceClient.create_from_connection_string(device_connection_string, connection_retry=False)
+        if (mode_rest == False):
+            device_client = IoTHubDeviceClient.create_from_connection_string(device_connection_string, connection_retry=False)
     else:
         print("Missing configuration file.")
         exit(0)


### PR DESCRIPTION
We create the iot device connection only if REST is false, i.e. not configured as IOT.